### PR TITLE
avoid shadowing outer local variable

### DIFF
--- a/lib/open-uri/cached.rb
+++ b/lib/open-uri/cached.rb
@@ -38,7 +38,7 @@ module OpenURI
         # Read metadata, if it exists
         meta = YAML::load(File.read("#{filename}.meta")) if File.exist?("#{filename}.meta")
 
-        f = File.exist?(filename) ? StringIO.new(File.open(filename, "rb") { |f| f.read }) : nil
+        f = File.exist?(filename) ? StringIO.new(File.open(filename, "rb") { |fd| fd.read }) : nil
 
         # Add meta accessors
         if meta && f


### PR DESCRIPTION
fix warning about shadowing outer local variable by changing variable name

Using this gem currently produces the following warning (when warnings are enabled):

```
open-uri-cached-0.0.5/lib/open-uri/cached.rb:41: warning: shadowing outer local variable - f
```